### PR TITLE
Send os to builder compute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-create-agent-js-client",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-create-agent-js-client",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "JS module providing discovery of the Arduino Create Plugin and communication with it",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -119,7 +119,7 @@ export default class Daemon {
     // Fetch command line for the board
     fetch(`${this.BOARDS_URL}/${target.board}/compute`, {
       method: 'POST',
-      body: JSON.stringify({ action: 'upload', verbose })
+      body: JSON.stringify({ action: 'upload', verbose, os: this.agentInfo.os })
     })
       .then(result => result.json())
       .then(uploadCommandInfo => {


### PR DESCRIPTION
With arduino-create-agent 1.1.82 the info command return the
operating system in which the agent is installed.
We then send it to builder-api boards compute to obtain the
urls of the required tools for an upload.
This will allow create-agent in the future to be more simple
and to obtain the urls from builder-api rather than from the parsing
of the (multiple) package_index