### PR TITLE
Bump webpack-dev-server version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "rollup-watch": "^4.3.1",
     "webpack": "^4.39.3",
     "webpack-cli": "^3.3.10",
-    "webpack-dev-server": "^3.7.2"
+    "webpack-dev-server": "^3.9.0"
   },
   "scripts": {
     "test": "",


### PR DESCRIPTION
Bumps `webpack-dev-server` from 3.7.2 to 3.9.0.

Linked to https://github.com/arduino/arduino-create-agent-js-client/pull/232