### PR TITLE
check all ports on agent disconnect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-create-agent-js-client",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-create-agent-js-client",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "JS module providing discovery of the Arduino Create Plugin and communication with it",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/socket-daemon.js
+++ b/src/socket-daemon.js
@@ -110,7 +110,10 @@ export default class SocketDaemon extends Daemon {
           this.agentInfo = data;
           this.agentFound.next(true);
         }))
-        .catch(() => timer(POLLING_INTERVAL).subscribe(() => this.findAgent()));
+        .catch(() => timer(POLLING_INTERVAL).subscribe(() => {
+          this.pluginURL = null;
+          this.findAgent();
+        }));
       return;
     }
 


### PR DESCRIPTION
When the agent crashes, it's very likely that when the users re-launch it will run on a different port. This is causing bugs on every app that uses this lib because there's no way to find it again when this happens.