### PR TITLE
update agent autoupdate behaviour

### DIFF
--- a/src/socket-daemon.js
+++ b/src/socket-daemon.js
@@ -165,7 +165,7 @@ export default class SocketDaemon extends Daemon {
         if (found) {
           return fetch('https://s3.amazonaws.com/arduino-create-static/agent-metadata/agent-version.json')
             .then(response => response.json().then(data => {
-              if (this.agentInfo.version && (semVerCompare(this.agentInfo.version, data.Version) = 0 || this.agentInfo.version.indexOf('dev') !== -1 || this.agentInfo.version.indexOf('rc') !== -1)) {
+              if (this.agentInfo.version && (semVerCompare(this.agentInfo.version, data.Version) === 0 || this.agentInfo.version.indexOf('dev') !== -1 || this.agentInfo.version.indexOf('rc') !== -1)) {
                 return this.agentInfo;
               }
 

--- a/src/socket-daemon.js
+++ b/src/socket-daemon.js
@@ -165,7 +165,7 @@ export default class SocketDaemon extends Daemon {
         if (found) {
           return fetch('https://s3.amazonaws.com/arduino-create-static/agent-metadata/agent-version.json')
             .then(response => response.json().then(data => {
-              if (this.agentInfo.version && (semVerCompare(this.agentInfo.version, data.Version) >= 0 || this.agentInfo.version.indexOf('dev') !== -1)) {
+              if (this.agentInfo.version && (semVerCompare(this.agentInfo.version, data.Version) = 0 || this.agentInfo.version.indexOf('dev') !== -1 || this.agentInfo.version.indexOf('rc') !== -1)) {
                 return this.agentInfo;
               }
 


### PR DESCRIPTION
- Now it's possible to rollback the agent  by modifying the `agent-version.json` on s3
- Update mechanism is not triggered anymore if the agent contains a semver with `rc` (e.g. 1.2.1-rc1)