### PR TITLE
use double quotes in programmer field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-create-agent-js-client",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "JS module providing discovery of the Arduino Create Plugin and communication with it",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/firmware-updater.js
+++ b/src/firmware-updater.js
@@ -205,7 +205,7 @@ export default class FirmwareUpdater {
         const data = {
           board: boardId,
           port,
-          commandline: `"{runtime.tools.fwupdater.path}/${updaterBinaryName}" -flasher {network.password} -port {serial.port} -restore_binary "{build.path}/{build.project_name}.bin" -programmer ${programmer}`,
+          commandline: `"{runtime.tools.fwupdater.path}/${updaterBinaryName}" -flasher {network.password} -port {serial.port} -restore_binary "{build.path}/{build.project_name}.bin" -programmer "${programmer}"`,
           hex: '',
           extra: {
             auth: {


### PR DESCRIPTION
By using double quotes in the programmer field the path does not get split by the agent in case of a whitespace.
Followup of #455 