### PR TITLE
Support compilation extrafiles on ChromeOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-create-agent-js-client",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "JS module providing discovery of the Arduino Create Plugin and communication with it",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/chrome-app-daemon.js
+++ b/src/chrome-app-daemon.js
@@ -237,10 +237,9 @@ export default class ChromeOsDaemon extends Daemon {
    *   data: "compiled sketch"
    * }
    */
-  _upload({
-    board, port, commandline, data
-  }) {
-    try {
+  _upload(uploadPayload, uploadCommandInfo) {
+    const { board, port, commandline, data } = uploadPayload;
+      try {
       window.oauth.token().then(token => {
         this.channel.postMessage({
           command: 'upload',
@@ -249,7 +248,8 @@ export default class ChromeOsDaemon extends Daemon {
             port,
             commandline,
             data,
-            token: token.token
+            token: token.token,
+            extrafiles: uploadCommandInfo.files || []
           }
         });
       });

--- a/src/chrome-app-daemon.js
+++ b/src/chrome-app-daemon.js
@@ -239,7 +239,7 @@ export default class ChromeOsDaemon extends Daemon {
    */
   _upload(uploadPayload, uploadCommandInfo) {
     const { board, port, commandline, data } = uploadPayload;
-    const extrafiles = uploadCommandInfo && uploadCommandInfo.files && Array.isArray(uploadCommandInfo.files) || []
+    const extrafiles = uploadCommandInfo && uploadCommandInfo.files && Array.isArray(uploadCommandInfo.files) ? uploadCommandInfo.files : [];
     try {
       window.oauth.token().then(token => {
         this.channel.postMessage({

--- a/src/chrome-app-daemon.js
+++ b/src/chrome-app-daemon.js
@@ -239,7 +239,8 @@ export default class ChromeOsDaemon extends Daemon {
    */
   _upload(uploadPayload, uploadCommandInfo) {
     const { board, port, commandline, data } = uploadPayload;
-      try {
+    const extrafiles = uploadCommandInfo && uploadCommandInfo.files && Array.isArray(uploadCommandInfo.files) || []
+    try {
       window.oauth.token().then(token => {
         this.channel.postMessage({
           command: 'upload',
@@ -249,7 +250,7 @@ export default class ChromeOsDaemon extends Daemon {
             commandline,
             data,
             token: token.token,
-            extrafiles: uploadCommandInfo.files || []
+            extrafiles
           }
         });
       });


### PR DESCRIPTION
Similarly to what has been done in #498, we're adding support to compilation `extrafiles` on ChromeOS as well.
See also https://github.com/arduino/arduino-create-agent-js-client/pull/498