### PR TITLE
Releasing 2.9.0 with RP2040 support and improved interactions with We…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@
 # arduino-create-agent-js-client
 JS module providing discovery of the [Arduino Create Agent](https://github.com/arduino/arduino-create-agent) and communication with it
 
-
 ## Changelog
-[2.9.0-beta.1] - 2022-05-17
+[2.9.0] - 2022-06-06
 
 ### Added
-- Improved support (still in Beta) for Chrome's Web Serial API on ChromeOS. Other operating systems should not be affected.
 - Added support for "Arduino RP2040 Connect" board
+### Changed
+- Improved support for Chrome's Web Serial API on ChromeOS. Other operating systems should not be affected.
 - Simplified the communication with the Web Serial API via a messaging system which simulates
   the [postMessage](https://developer.chrome.com/docs/extensions/reference/runtime/#method-Port-postMessage) function available in the Chrome App Daemon (see `chrome-app-daemon.js`).
+
 
 [2.8.0] - 2022-03-21
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-create-agent-js-client",
-  "version": "2.9.0-beta.2",
+  "version": "2.9.0",
   "description": "JS module providing discovery of the Arduino Create Plugin and communication with it",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
Releasing version 2.9.0.
## Changelog
[2.9.0] - 2022-06-06

### Added
- Added support for "Arduino RP2040 Connect" board
### Changed
- Improved support for Chrome's Web Serial API on ChromeOS. Other operating systems should not be affected.
- Simplified the communication with the Web Serial API via a messaging system which simulates
  the [postMessage](https://developer.chrome.com/docs/extensions/reference/runtime/#method-Port-postMessage) function available in the Chrome App Daemon (see `chrome-app-daemon.js`).