### PR TITLE
Throwing an error when device is not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ JS module providing discovery of the [Arduino Create Agent](https://github.com/a
 
 
 ## Changelog
+[2.9.1-alpha.2] - 2022-08-17
+
+### Changed
+- The error `No device found` coming from the `arduino-create-agent` is now treated as an error.
+
+## Changelog
 [2.9.1-alpha.1] - 2022-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,9 +4,15 @@
 # arduino-create-agent-js-client
 JS module providing discovery of the [Arduino Create Agent](https://github.com/arduino/arduino-create-agent) and communication with it
 
+
+## Changelog
+[2.9.1-alpha.1] - 2022-07-28
+
+### Added
+- Added support for ESP boards (experimental)
+
 ## Changelog
 [2.9.0] - 2022-06-06
-
 ### Added
 - Added support for "Arduino RP2040 Connect" board
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-create-agent-js-client",
-  "version": "2.9.1-alpha.1",
+  "version": "2.9.1-alpha.2",
   "description": "JS module providing discovery of the Arduino Create Plugin and communication with it",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-create-agent-js-client",
-  "version": "2.9.0",
+  "version": "2.9.1-alpha.1",
   "description": "JS module providing discovery of the Arduino Create Plugin and communication with it",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -130,7 +130,7 @@ export default class Daemon {
     })
       .then(result => result.json())
       .then(uploadCommandInfo => {
-        const projectNameIndex = uploadCommandInfo.commandline.indexOf('{build.project_name}');
+        const projectNameIndex = uploadCommandInfo.commandline.lastIndexOf('{build.project_name}');
         let ext = uploadCommandInfo.commandline.substring(projectNameIndex + 21, projectNameIndex + 24);
         const data = compilationResult[ext] || compilationResult.bin;
         if (!ext || !data) {

--- a/src/socket-daemon.js
+++ b/src/socket-daemon.js
@@ -392,7 +392,12 @@ export default class SocketDaemon extends Daemon {
         this.uploading.next({ status: this.UPLOAD_IN_PROGRESS, msg: `Programming with: ${message.Cmd}` });
         break;
       case 'Busy':
-        this.uploading.next({ status: this.UPLOAD_IN_PROGRESS, msg: message.Msg });
+        if (message.Msg && message.Msg.indexOf('No device found') === 0) {
+          this.uploading.next({ status: this.UPLOAD_ERROR, err: message.Msg });
+        }
+        else {
+          this.uploading.next({ status: this.UPLOAD_IN_PROGRESS, msg: message.Msg });
+        }
         break;
       case 'Error':
         this.uploading.next({ status: this.UPLOAD_ERROR, err: message.Msg });


### PR DESCRIPTION
WARNING: this updated is still in alpha version, not tested in production environment yet.
- Throwing an error when device is not found. It was an 'in progress' message before.
- Updated logic to extract the file extension when uploading a sketch