### PR TITLE
Fixed file extension calculation for ESP32 boards.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib
 dist
 es
 .tmp
+misc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [2.9.1] - 2022-09-06
+## [2.10.0] - 2022-09-08
+
+### Changed
+- Fixed a bug released in 2.9.1 caused by the wrong assumption that the build filename is always at the end of the command line. This fix makes the library backward compatible with older ESP boards.
+
+## *DEPRECATED* [2.9.1] - 2022-09-06
 ### Added
 - Added support for ESP32 boards
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 JS module providing discovery of the [Arduino Create Agent](https://github.com/arduino/arduino-create-agent) and communication with it
 
 ## Changelog
-See [CHANGELOG.MD](CHANGELOG.MD) for more details.
+See [CHANGELOG.md](https://github.com/arduino/arduino-create-agent-js-client/blob/HEAD/CHANGELOG.md) for more details.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-create-agent-js-client",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "JS module providing discovery of the Arduino Create Plugin and communication with it",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -130,8 +130,7 @@ export default class Daemon {
     })
       .then(result => result.json())
       .then(uploadCommandInfo => {
-        const projectNameIndex = uploadCommandInfo.commandline.lastIndexOf('{build.project_name}');
-        let ext = uploadCommandInfo.commandline.substring(projectNameIndex + 21, projectNameIndex + 24);
+        let ext = this._extractExtensionFromCommandline(uploadCommandInfo.commandline);
         const data = compilationResult[ext] || compilationResult.bin;
         if (!ext || !data) {
           console.log('we received a faulty ext property, defaulting to .bin');
@@ -210,5 +209,14 @@ export default class Daemon {
       timer(1000).subscribe(() => this.closeSerialMonitor(port));
     });
     this.openSerialMonitor(port, 1200);
+  }
+
+  static _extractExtensionFromCommandline(commandline) {
+    const rx = /\{build\.project_name\}\.(\w\w\w)\b/g;
+    const arr = rx.exec(commandline);
+    if (arr && arr.length) {
+      return arr[1];
+    }
+    return null;
   }
 }


### PR DESCRIPTION
This commit fixes a bug introduced with 2.9.1 (which will be deprecated).

Now the file extension of the sketch is retrieved using a regular expression, not by position.