### PR TITLE
Improved support for Web Serial API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
   It has no effect with other daemons.
 
 ### Removed
-- `connectToSerialDevice` functionality, now it's embedded in the `upload` functionality
+- `cdcReset` functionality, now it's embedded in the `upload` functionality
   in the Web Serial daemon.
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,21 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [2.10.0] - 2022-09-08
+## [2.11.0] - 2022-09-27
+
+### Changed
+- When using Web Serial API, the interactions between the client library
+  (as an example, the Arduino `arduino-chromeos-uploader` libray) has been simplified.
+- A new parameter `dialogCustomizations` has been added to the upload functionality. It's used
+  to provide custom confirmation dialogs when using the Web Serial API.
+  It has no effect with other daemons.
+
+### Removed
+- `connectToSerialDevice` functionality, now it's embedded in the `upload` functionality
+  in the Web Serial daemon.
+### Changed
+
+## [2.10.1] - 2022-09-08
 
 ### Changed
 - Fixed a bug released in 2.9.1 caused by the wrong assumption that the build filename is always at the end of the command line. This fix makes the library backward compatible with older ESP boards.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-create-agent-js-client",
-  "version": "2.10.1",
+  "version": "2.11.0-alpha.2",
   "description": "JS module providing discovery of the Arduino Create Plugin and communication with it",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -115,8 +115,12 @@ export default class Daemon {
    * @param {string} sketchName
    * @param {Object} compilationResult
    * @param {boolean} verbose
+   * @param {any[]} dialogCustomizations Optional - Used in Web Serial API to customize the permission dialogs.
+   *        It's an array because the Web Serial API library can use more than one dialog, e.g. one to
+   *        ask permission and one to give instruction to save an UF2 file.
+   *        It's called 'customizations' because the library already provides a basic non-styled dialog.
    */
-  uploadSerial(target, sketchName, compilationResult, verbose = true) {
+  uploadSerial(target, sketchName, compilationResult, verbose = true, dialogCustomizations) {
     this.uploadingPort = target.port;
     this.uploading.next({ status: this.UPLOAD_IN_PROGRESS, msg: 'Upload started' });
     this.serialDevicesBeforeUpload = this.devicesList.getValue().serial;
@@ -142,7 +146,8 @@ export default class Daemon {
           commandline: uploadCommandInfo.commandline,
           filename: `${sketchName}.${ext}`,
           hex: data, // For desktop agent
-          data // For chromeOS plugin, consider to align this
+          data, // For chromeOS plugin, consider to align this
+          dialogCustomizations // used only in Web Serial API uploader
         };
 
         this.uploadingDone.subscribe(() => {


### PR DESCRIPTION
* Now the interaction between the client library (e.g. the Arduino `arduino-chromeos-uploader` library) has been simplified.

* Added a parameter to pass dialog customization to the web serial api uploader library

* Removed `cdcReset` function from the Web Serial API daemon.

* Added  functionality to write on the serial port