### PR TITLE
Use download servers to obtain the latest agent version

### DIFF
--- a/src/socket-daemon.js
+++ b/src/socket-daemon.js
@@ -163,7 +163,7 @@ export default class SocketDaemon extends Daemon {
         });
 
         if (found) {
-          return fetch('https://s3.amazonaws.com/arduino-create-static/agent-metadata/agent-version.json')
+          return fetch('https://downloads.arduino.cc/agent-metadata/agent-version.json')
             .then(response => response.json().then(data => {
               if (this.agentInfo.version && (semVerCompare(this.agentInfo.version, data.Version) === 0 || this.agentInfo.version.indexOf('dev') !== -1 || this.agentInfo.version.indexOf('rc') !== -1)) {
                 return this.agentInfo;


### PR DESCRIPTION
`agent-version.json` has been moved to the download servers, so it should be retrieved using the correct URL.
Follow up to https://github.com/arduino/arduino-create-agent/pull/896.