### PR TITLE
Use download servers to obtain the latest agent version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-create-agent-js-client",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "JS module providing discovery of the Arduino Create Plugin and communication with it",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/socket-daemon.js
+++ b/src/socket-daemon.js
@@ -163,7 +163,7 @@ export default class SocketDaemon extends Daemon {
         });
 
         if (found) {
-          return fetch('https://s3.amazonaws.com/arduino-create-static/agent-metadata/agent-version.json')
+          return fetch('https://downloads.arduino.cc/agent-metadata/agent-version.json')
             .then(response => response.json().then(data => {
               if (this.agentInfo.version && (semVerCompare(this.agentInfo.version, data.Version) === 0 || this.agentInfo.version.indexOf('dev') !== -1 || this.agentInfo.version.indexOf('rc') !== -1)) {
                 return this.agentInfo;


### PR DESCRIPTION
### Motivation
`agent-version.json` has been moved to the download servers, so it should be retrieved using the correct URL.

### Change description
The URL to retrieve the latest agent version has been changed.

### Additional Notes
Follow up to [arduino/arduino-create-agent#896](https://github.com/arduino/arduino-create-agent/pull/896).

### Reviewer checklist
* [ ]  PR address a single concern.
* [ ]  PR title and description are properly filled.
* [ ]  Changes will be merged in `main`.
* [ ]  Changes are covered by tests.
* [ ]  Logging is meaningful in case of troubleshooting.
* [ ]  History is clean, commit messages are meaningful and are well formatted.